### PR TITLE
Use :focus-visible for interactive elements

### DIFF
--- a/JsonWebTokenError.js
+++ b/JsonWebTokenError.js
@@ -1,0 +1,14 @@
+var JsonWebTokenError = function (message, error) {
+  Error.call(this, message);
+  if(Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+  this.name = 'JsonWebTokenError';
+  this.message = message;
+  if (error) this.inner = error;
+};
+
+JsonWebTokenError.prototype = Object.create(Error.prototype);
+JsonWebTokenError.prototype.constructor = JsonWebTokenError;
+
+module.exports = JsonWebTokenError;


### PR DESCRIPTION
Replace global :focus with :focus-visible to avoid showing focus outlines during mouse interactions while preserving keyboard accessibility. Updated styles to apply outline and outline-offset for buttons/links and added a small .focus-visible fallback for browsers without native support.